### PR TITLE
Revert "test: read_ack"

### DIFF
--- a/src/worker.rs
+++ b/src/worker.rs
@@ -4,7 +4,7 @@ use log::warn;
 use rmp_serde::Serializer;
 use serde::{ser::SerializeMap, Deserialize, Serialize};
 use tokio::{
-    io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt, BufWriter},
+    io::{AsyncReadExt, AsyncWriteExt},
     net::TcpStream,
     time::Duration,
 };
@@ -72,7 +72,7 @@ struct SerializedRecord {
     chunk: String,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Deserialize)]
 struct AckResponse {
     ack: String,
 }
@@ -83,19 +83,16 @@ pub struct RetryConfig {
     pub max_wait: u64,
 }
 
-pub struct Worker<T = TcpStream> {
-    stream: BufWriter<T>,
+pub struct Worker {
+    stream: TcpStream,
     receiver: Receiver<Message>,
     retry_config: RetryConfig,
 }
 
-impl<T> Worker<T>
-where
-    T: AsyncWrite + AsyncRead + Unpin,
-{
-    pub fn new(stream: T, receiver: Receiver<Message>, retry_config: RetryConfig) -> Self {
+impl Worker {
+    pub fn new(stream: TcpStream, receiver: Receiver<Message>, retry_config: RetryConfig) -> Self {
         Self {
-            stream: BufWriter::new(stream),
+            stream,
             receiver,
             retry_config,
         }
@@ -190,34 +187,5 @@ where
                 return Err(Error::ConnectionClosed);
             }
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[tokio::test]
-    async fn test_read_ack() {
-        let (client, mut server) = tokio::io::duplex(64);
-        let (_, receiver) = channel::unbounded();
-        let retry_config = RetryConfig {
-            initial_wait: 50,
-            max: 13,
-            max_wait: 60000,
-        };
-        let mut worker = Worker::new(client, receiver, retry_config);
-
-        let ack_response = AckResponse {
-            ack: "Mzc4NDQwMzctNGY4Ni00MmI2LWFiYjMtMjk3MGZkNDUzY2Y2".to_string(),
-        };
-        let ack_response = rmp_serde::to_vec(&ack_response).unwrap();
-        server.write_all(&ack_response).await.unwrap();
-
-        let ack = worker.read_ack().await.expect("failed to read ack");
-        assert_eq!(
-            ack.ack,
-            "Mzc4NDQwMzctNGY4Ni00MmI2LWFiYjMtMjk3MGZkNDUzY2Y2".to_string()
-        );
     }
 }


### PR DESCRIPTION
This reverts commit 287ed4126581ec8c06c1d053c8b5f11c36656033.
BufWriter needs to call `flush()` but this type is for testing only.
Revert it for now.